### PR TITLE
added offset and limit for returned cached values

### DIFF
--- a/lib/SequelizeRedisModel.js
+++ b/lib/SequelizeRedisModel.js
@@ -107,7 +107,7 @@ var SequelizeRedisModel = function () {
           args[_key2 - 2] = arguments[_key2];
         }
 
-        var cached, parsed, _result, queryOptions, buildOptions, result, toCache;
+        var cached, parsed, _result, queryOptions, buildOptions, offset, limit, result, toCache;
 
         return _regenerator2.default.wrap(function _callee3$(_context3) {
           while (1) {
@@ -189,7 +189,15 @@ var SequelizeRedisModel = function () {
                   if (queryOptions.include) {
                     buildOptions.include = queryOptions.include;
                   }
+
                   _result = this.model.build(parsed, buildOptions);
+
+                  if (queryOptions.offset || queryOptions.limit) {
+                    offset = queryOptions.offset || 0;
+                    limit = queryOptions.limit || _result.length;
+
+                    _result = _result.slice(offset, limit);
+                  }
                 } else {
                   _result = this.model.build(parsed);
                 }

--- a/lib/SequelizeRedisModel.js
+++ b/lib/SequelizeRedisModel.js
@@ -196,7 +196,7 @@ var SequelizeRedisModel = function () {
                     offset = queryOptions.offset || 0;
                     limit = queryOptions.limit || _result.length;
 
-                    _result = _result.slice(offset, limit);
+                    _result = _result.splice(offset, limit);
                   }
                 } else {
                   _result = this.model.build(parsed);

--- a/lib/SequelizeRedisModel.js
+++ b/lib/SequelizeRedisModel.js
@@ -146,7 +146,7 @@ var SequelizeRedisModel = function () {
 
               case 14:
                 if (!cached) {
-                  _context3.next = 32;
+                  _context3.next = 33;
                   break;
                 }
 
@@ -167,8 +167,12 @@ var SequelizeRedisModel = function () {
 
                 // console.log('From Cache');
                 _result = void 0;
+                queryOptions = args[0];
 
-                if (parsed.rows) {
+
+                if (queryOptions && !!queryOptions.raw) {
+                  _result = parsed;
+                } else if (parsed.rows) {
                   _result = (0, _extends3.default)({}, parsed, {
                     rows: parsed.rows.map(function (parsedRow) {
                       return _this2.model.build(parsedRow);
@@ -176,71 +180,67 @@ var SequelizeRedisModel = function () {
                   });
                 } else if (typeof parsed === 'number') {
                   _result = parsed;
-                } else {
-                  queryOptions = args[0];
+                } else if (queryOptions) {
+                  buildOptions = {
+                    raw: !!queryOptions.raw,
+                    isNewRecord: !!queryOptions.isNewRecord
+                  };
 
-                  if (queryOptions) {
-                    buildOptions = {
-                      raw: !!queryOptions.raw || false,
-                      isNewRecord: !!queryOptions.isNewRecord || false
-                    };
-
-                    if (queryOptions.include) {
-                      buildOptions.include = queryOptions.include;
-                    }
-                    _result = this.model.build(parsed, buildOptions);
-                  } else {
-                    _result = this.model.build(parsed);
+                  if (queryOptions.include) {
+                    buildOptions.include = queryOptions.include;
                   }
+                  _result = this.model.build(parsed, buildOptions);
+                } else {
+                  _result = this.model.build(parsed);
                 }
 
                 return _context3.abrupt('return', [_result, true]);
 
-              case 29:
-                _context3.prev = 29;
+              case 30:
+                _context3.prev = 30;
                 _context3.t2 = _context3['catch'](23);
                 throw new Error('Cant build model from cached JSON: ' + _context3.t2.message);
 
-              case 32:
-                _context3.next = 34;
+              case 33:
+                _context3.next = 35;
                 return (_model2 = this.model)[method].apply(_model2, args);
 
-              case 34:
+              case 35:
                 result = _context3.sent;
                 toCache = void 0;
 
                 if (result) {
-                  _context3.next = 40;
+                  _context3.next = 41;
                   break;
                 }
 
                 return _context3.abrupt('return', [null, false]);
 
-              case 40:
+              case 41:
                 if (!(Array.isArray(result) || result.rows || typeof result === 'number')) {
-                  _context3.next = 44;
+                  _context3.next = 45;
                   break;
                 }
 
                 // Array for findAll, result.rows for findAndCountAll, typeof number for count/max/sum/etc
                 toCache = result;
-                _context3.next = 49;
+                _context3.next = 50;
                 break;
 
-              case 44:
+              case 45:
                 if (!result.toString().includes('[object SequelizeInstance')) {
-                  _context3.next = 48;
+                  _context3.next = 49;
                   break;
                 }
 
                 toCache = result;
-                _context3.next = 49;
+                _context3.next = 50;
                 break;
 
-              case 48:
+              case 49:
                 throw new Error('Unkown result type: ' + (typeof result === 'undefined' ? 'undefined' : (0, _typeof3.default)(result)));
 
-              case 49:
+              case 50:
 
                 this.redisClient.set(cacheKey, (0, _jsonBuffer.stringify)(toCache));
 
@@ -250,12 +250,12 @@ var SequelizeRedisModel = function () {
 
                 return _context3.abrupt('return', [result, false]);
 
-              case 52:
+              case 53:
               case 'end':
                 return _context3.stop();
             }
           }
-        }, _callee3, this, [[5, 11], [16, 20], [23, 29]]);
+        }, _callee3, this, [[5, 11], [16, 20], [23, 30]]);
       }));
 
       function run(_x3, _x4) {

--- a/lib/SequelizeRedisModel.js
+++ b/lib/SequelizeRedisModel.js
@@ -107,7 +107,7 @@ var SequelizeRedisModel = function () {
           args[_key2 - 2] = arguments[_key2];
         }
 
-        var cached, parsed, _result, queryOptions, buildOptions, offset, limit, result, toCache;
+        var cached, parsed, _result, queryOptions, buildOptions, result, toCache;
 
         return _regenerator2.default.wrap(function _callee3$(_context3) {
           while (1) {
@@ -172,6 +172,9 @@ var SequelizeRedisModel = function () {
 
                 if (queryOptions && !!queryOptions.raw) {
                   _result = parsed;
+                  if (queryOptions.offset || queryOptions.limit) {
+                    _result = _result.splice(queryOptions.offset || 0, queryOptions.limit || _result.length);
+                  }
                 } else if (parsed.rows) {
                   _result = (0, _extends3.default)({}, parsed, {
                     rows: parsed.rows.map(function (parsedRow) {
@@ -193,12 +196,10 @@ var SequelizeRedisModel = function () {
                   _result = this.model.build(parsed, buildOptions);
 
                   if (queryOptions.offset || queryOptions.limit) {
-                    offset = queryOptions.offset || 0;
-                    limit = queryOptions.limit || _result.length;
-
-                    _result = _result.splice(offset, limit);
+                    _result = _result.splice(queryOptions.offset || 0, queryOptions.limit || _result.length);
                   }
                 } else {
+
                   _result = this.model.build(parsed);
                 }
 

--- a/lib/test/sequelize-redis.js
+++ b/lib/test/sequelize-redis.js
@@ -538,15 +538,45 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee14, undefined);
   })));
 
-  it('should fetch user with includes from database', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee15() {
-    var _ref36, _ref37, user, isCached;
+  it('should fetch users from cache with offset and limit with raw', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee15() {
+    var limit, _ref36, _ref37, users, isCached;
 
     return _regenerator2.default.wrap(function _callee15$(_context15) {
       while (1) {
         switch (_context15.prev = _context15.next) {
           case 0:
-            redisClient.del(cacheKey);
+            limit = 1;
             _context15.next = 3;
+            return UserCacher.findAllCached(cacheKey, { raw: true, offset: 1, limit: limit });
+
+          case 3:
+            _ref36 = _context15.sent;
+            _ref37 = (0, _slicedToArray3.default)(_ref36, 2);
+            users = _ref37[0];
+            isCached = _ref37[1];
+
+            _should2.default.exist(users);
+            users.length.should.equal(limit);
+            isCached.should.equal(true);
+            users[0].username.should.equal('idan2');
+
+          case 11:
+          case 'end':
+            return _context15.stop();
+        }
+      }
+    }, _callee15, undefined);
+  })));
+
+  it('should fetch user with includes from database', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee16() {
+    var _ref39, _ref40, user, isCached;
+
+    return _regenerator2.default.wrap(function _callee16$(_context16) {
+      while (1) {
+        switch (_context16.prev = _context16.next) {
+          case 0:
+            redisClient.del(cacheKey);
+            _context16.next = 3;
             return UserCacher.findOneCached(cacheKey, {
               where: {
                 id: 1
@@ -555,10 +585,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 3:
-            _ref36 = _context15.sent;
-            _ref37 = (0, _slicedToArray3.default)(_ref36, 2);
-            user = _ref37[0];
-            isCached = _ref37[1];
+            _ref39 = _context16.sent;
+            _ref40 = (0, _slicedToArray3.default)(_ref39, 2);
+            user = _ref40[0];
+            isCached = _ref40[1];
 
             isCached.should.equal(false);
             _should2.default.exist(user);
@@ -568,20 +598,20 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 12:
           case 'end':
-            return _context15.stop();
+            return _context16.stop();
         }
       }
-    }, _callee15, undefined);
+    }, _callee16, undefined);
   })));
 
-  it('should fetch user with includes from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee16() {
-    var _ref39, _ref40, user, isCached;
+  it('should fetch user with includes from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee17() {
+    var _ref42, _ref43, user, isCached;
 
-    return _regenerator2.default.wrap(function _callee16$(_context16) {
+    return _regenerator2.default.wrap(function _callee17$(_context17) {
       while (1) {
-        switch (_context16.prev = _context16.next) {
+        switch (_context17.prev = _context17.next) {
           case 0:
-            _context16.next = 2;
+            _context17.next = 2;
             return UserCacher.findOneCached(cacheKey, {
               where: {
                 id: 1
@@ -590,10 +620,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 2:
-            _ref39 = _context16.sent;
-            _ref40 = (0, _slicedToArray3.default)(_ref39, 2);
-            user = _ref40[0];
-            isCached = _ref40[1];
+            _ref42 = _context17.sent;
+            _ref43 = (0, _slicedToArray3.default)(_ref42, 2);
+            user = _ref43[0];
+            isCached = _ref43[1];
 
             isCached.should.equal(true);
             _should2.default.exist(user);
@@ -603,21 +633,21 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 11:
           case 'end':
-            return _context16.stop();
+            return _context17.stop();
         }
       }
-    }, _callee16, undefined);
+    }, _callee17, undefined);
   })));
 
-  it('should findAndCountAll from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee17() {
-    var _ref42, _ref43, res, isCached;
+  it('should findAndCountAll from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee18() {
+    var _ref45, _ref46, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee17$(_context17) {
+    return _regenerator2.default.wrap(function _callee18$(_context18) {
       while (1) {
-        switch (_context17.prev = _context17.next) {
+        switch (_context18.prev = _context18.next) {
           case 0:
             redisClient.del(cacheKey);
-            _context17.next = 3;
+            _context18.next = 3;
             return UserCacher.findAndCountAllCached(cacheKey, {
               where: {
                 username: 'idan'
@@ -625,10 +655,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 3:
-            _ref42 = _context17.sent;
-            _ref43 = (0, _slicedToArray3.default)(_ref42, 2);
-            res = _ref43[0];
-            isCached = _ref43[1];
+            _ref45 = _context18.sent;
+            _ref46 = (0, _slicedToArray3.default)(_ref45, 2);
+            res = _ref46[0];
+            isCached = _ref46[1];
 
 
             isCached.should.equal(false);
@@ -640,20 +670,20 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 13:
           case 'end':
-            return _context17.stop();
+            return _context18.stop();
         }
       }
-    }, _callee17, undefined);
+    }, _callee18, undefined);
   })));
 
-  it('should findAndCountAll from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee18() {
-    var _ref45, _ref46, res, isCached;
+  it('should findAndCountAll from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee19() {
+    var _ref48, _ref49, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee18$(_context18) {
+    return _regenerator2.default.wrap(function _callee19$(_context19) {
       while (1) {
-        switch (_context18.prev = _context18.next) {
+        switch (_context19.prev = _context19.next) {
           case 0:
-            _context18.next = 2;
+            _context19.next = 2;
             return UserCacher.findAndCountAllCached(cacheKey, {
               where: {
                 username: 'idan'
@@ -661,10 +691,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 2:
-            _ref45 = _context18.sent;
-            _ref46 = (0, _slicedToArray3.default)(_ref45, 2);
-            res = _ref46[0];
-            isCached = _ref46[1];
+            _ref48 = _context19.sent;
+            _ref49 = (0, _slicedToArray3.default)(_ref48, 2);
+            res = _ref49[0];
+            isCached = _ref49[1];
 
 
             isCached.should.equal(true);
@@ -676,21 +706,21 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 12:
           case 'end':
-            return _context18.stop();
+            return _context19.stop();
         }
       }
-    }, _callee18, undefined);
+    }, _callee19, undefined);
   })));
 
-  it('should count from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee19() {
-    var _ref48, _ref49, res, isCached;
+  it('should count from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee20() {
+    var _ref51, _ref52, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee19$(_context19) {
+    return _regenerator2.default.wrap(function _callee20$(_context20) {
       while (1) {
-        switch (_context19.prev = _context19.next) {
+        switch (_context20.prev = _context20.next) {
           case 0:
             redisClient.del(cacheKey);
-            _context19.next = 3;
+            _context20.next = 3;
             return UserCacher.countCached(cacheKey, {
               where: {
                 username: 'idan'
@@ -698,10 +728,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 3:
-            _ref48 = _context19.sent;
-            _ref49 = (0, _slicedToArray3.default)(_ref48, 2);
-            res = _ref49[0];
-            isCached = _ref49[1];
+            _ref51 = _context20.sent;
+            _ref52 = (0, _slicedToArray3.default)(_ref51, 2);
+            res = _ref52[0];
+            isCached = _ref52[1];
 
 
             isCached.should.equal(false);
@@ -709,39 +739,6 @@ describe('Sequelize-Redis-Cache', function () {
             res.should.equal(1);
 
           case 10:
-          case 'end':
-            return _context19.stop();
-        }
-      }
-    }, _callee19, undefined);
-  })));
-
-  it('should count from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee20() {
-    var _ref51, _ref52, res, isCached;
-
-    return _regenerator2.default.wrap(function _callee20$(_context20) {
-      while (1) {
-        switch (_context20.prev = _context20.next) {
-          case 0:
-            _context20.next = 2;
-            return UserCacher.countCached(cacheKey, {
-              where: {
-                username: 'idan'
-              }
-            });
-
-          case 2:
-            _ref51 = _context20.sent;
-            _ref52 = (0, _slicedToArray3.default)(_ref51, 2);
-            res = _ref52[0];
-            isCached = _ref52[1];
-
-
-            isCached.should.equal(true);
-            _should2.default.exist(res);
-            res.should.equal(1);
-
-          case 9:
           case 'end':
             return _context20.stop();
         }
@@ -749,29 +746,32 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee20, undefined);
   })));
 
-  it('should sum from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee21() {
+  it('should count from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee21() {
     var _ref54, _ref55, res, isCached;
 
     return _regenerator2.default.wrap(function _callee21$(_context21) {
       while (1) {
         switch (_context21.prev = _context21.next) {
           case 0:
-            redisClient.del(cacheKey);
-            _context21.next = 3;
-            return UserCacher.sumCached(cacheKey, 'id');
+            _context21.next = 2;
+            return UserCacher.countCached(cacheKey, {
+              where: {
+                username: 'idan'
+              }
+            });
 
-          case 3:
+          case 2:
             _ref54 = _context21.sent;
             _ref55 = (0, _slicedToArray3.default)(_ref54, 2);
             res = _ref55[0];
             isCached = _ref55[1];
 
 
-            isCached.should.equal(false);
+            isCached.should.equal(true);
             _should2.default.exist(res);
-            res.should.equal(3); // user id 1 + user id 2 = 3
+            res.should.equal(1);
 
-          case 10:
+          case 9:
           case 'end':
             return _context21.stop();
         }
@@ -779,21 +779,51 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee21, undefined);
   })));
 
-  it('should sum from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee22() {
+  it('should sum from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee22() {
     var _ref57, _ref58, res, isCached;
 
     return _regenerator2.default.wrap(function _callee22$(_context22) {
       while (1) {
         switch (_context22.prev = _context22.next) {
           case 0:
-            _context22.next = 2;
+            redisClient.del(cacheKey);
+            _context22.next = 3;
             return UserCacher.sumCached(cacheKey, 'id');
 
-          case 2:
+          case 3:
             _ref57 = _context22.sent;
             _ref58 = (0, _slicedToArray3.default)(_ref57, 2);
             res = _ref58[0];
             isCached = _ref58[1];
+
+
+            isCached.should.equal(false);
+            _should2.default.exist(res);
+            res.should.equal(3); // user id 1 + user id 2 = 3
+
+          case 10:
+          case 'end':
+            return _context22.stop();
+        }
+      }
+    }, _callee22, undefined);
+  })));
+
+  it('should sum from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee23() {
+    var _ref60, _ref61, res, isCached;
+
+    return _regenerator2.default.wrap(function _callee23$(_context23) {
+      while (1) {
+        switch (_context23.prev = _context23.next) {
+          case 0:
+            _context23.next = 2;
+            return UserCacher.sumCached(cacheKey, 'id');
+
+          case 2:
+            _ref60 = _context23.sent;
+            _ref61 = (0, _slicedToArray3.default)(_ref60, 2);
+            res = _ref61[0];
+            isCached = _ref61[1];
 
 
             isCached.should.equal(true);
@@ -802,28 +832,28 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 9:
           case 'end':
-            return _context22.stop();
+            return _context23.stop();
         }
       }
-    }, _callee22, undefined);
+    }, _callee23, undefined);
   })));
 
-  it('should max from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee23() {
-    var _ref60, _ref61, res, isCached;
+  it('should max from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee24() {
+    var _ref63, _ref64, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee23$(_context23) {
+    return _regenerator2.default.wrap(function _callee24$(_context24) {
       while (1) {
-        switch (_context23.prev = _context23.next) {
+        switch (_context24.prev = _context24.next) {
           case 0:
             redisClient.del(cacheKey);
-            _context23.next = 3;
+            _context24.next = 3;
             return UserCacher.maxCached(cacheKey, 'id');
 
           case 3:
-            _ref60 = _context23.sent;
-            _ref61 = (0, _slicedToArray3.default)(_ref60, 2);
-            res = _ref61[0];
-            isCached = _ref61[1];
+            _ref63 = _context24.sent;
+            _ref64 = (0, _slicedToArray3.default)(_ref63, 2);
+            res = _ref64[0];
+            isCached = _ref64[1];
 
 
             isCached.should.equal(false);
@@ -831,35 +861,6 @@ describe('Sequelize-Redis-Cache', function () {
             res.should.equal(2); // user id 2
 
           case 10:
-          case 'end':
-            return _context23.stop();
-        }
-      }
-    }, _callee23, undefined);
-  })));
-
-  it('should max from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee24() {
-    var _ref63, _ref64, res, isCached;
-
-    return _regenerator2.default.wrap(function _callee24$(_context24) {
-      while (1) {
-        switch (_context24.prev = _context24.next) {
-          case 0:
-            _context24.next = 2;
-            return UserCacher.maxCached(cacheKey, 'id');
-
-          case 2:
-            _ref63 = _context24.sent;
-            _ref64 = (0, _slicedToArray3.default)(_ref63, 2);
-            res = _ref64[0];
-            isCached = _ref64[1];
-
-
-            isCached.should.equal(true);
-            _should2.default.exist(res);
-            res.should.equal(2); // user id 2
-
-          case 9:
           case 'end':
             return _context24.stop();
         }
@@ -867,22 +868,51 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee24, undefined);
   })));
 
-  it('should min from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee25() {
+  it('should max from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee25() {
     var _ref66, _ref67, res, isCached;
 
     return _regenerator2.default.wrap(function _callee25$(_context25) {
       while (1) {
         switch (_context25.prev = _context25.next) {
           case 0:
-            redisClient.del(cacheKey);
-            _context25.next = 3;
-            return UserCacher.minCached(cacheKey, 'id');
+            _context25.next = 2;
+            return UserCacher.maxCached(cacheKey, 'id');
 
-          case 3:
+          case 2:
             _ref66 = _context25.sent;
             _ref67 = (0, _slicedToArray3.default)(_ref66, 2);
             res = _ref67[0];
             isCached = _ref67[1];
+
+
+            isCached.should.equal(true);
+            _should2.default.exist(res);
+            res.should.equal(2); // user id 2
+
+          case 9:
+          case 'end':
+            return _context25.stop();
+        }
+      }
+    }, _callee25, undefined);
+  })));
+
+  it('should min from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee26() {
+    var _ref69, _ref70, res, isCached;
+
+    return _regenerator2.default.wrap(function _callee26$(_context26) {
+      while (1) {
+        switch (_context26.prev = _context26.next) {
+          case 0:
+            redisClient.del(cacheKey);
+            _context26.next = 3;
+            return UserCacher.minCached(cacheKey, 'id');
+
+          case 3:
+            _ref69 = _context26.sent;
+            _ref70 = (0, _slicedToArray3.default)(_ref69, 2);
+            res = _ref70[0];
+            isCached = _ref70[1];
 
 
             isCached.should.equal(false);
@@ -891,27 +921,27 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 10:
           case 'end':
-            return _context25.stop();
+            return _context26.stop();
         }
       }
-    }, _callee25, undefined);
+    }, _callee26, undefined);
   })));
 
-  it('should min from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee26() {
-    var _ref69, _ref70, res, isCached;
+  it('should min from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee27() {
+    var _ref72, _ref73, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee26$(_context26) {
+    return _regenerator2.default.wrap(function _callee27$(_context27) {
       while (1) {
-        switch (_context26.prev = _context26.next) {
+        switch (_context27.prev = _context27.next) {
           case 0:
-            _context26.next = 2;
+            _context27.next = 2;
             return UserCacher.minCached(cacheKey, 'id');
 
           case 2:
-            _ref69 = _context26.sent;
-            _ref70 = (0, _slicedToArray3.default)(_ref69, 2);
-            res = _ref70[0];
-            isCached = _ref70[1];
+            _ref72 = _context27.sent;
+            _ref73 = (0, _slicedToArray3.default)(_ref72, 2);
+            res = _ref73[0];
+            isCached = _ref73[1];
 
 
             isCached.should.equal(true);
@@ -920,9 +950,9 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 9:
           case 'end':
-            return _context26.stop();
+            return _context27.stop();
         }
       }
-    }, _callee26, undefined);
+    }, _callee27, undefined);
   })));
 });

--- a/lib/test/sequelize-redis.js
+++ b/lib/test/sequelize-redis.js
@@ -508,28 +508,29 @@ describe('Sequelize-Redis-Cache', function () {
   })));
 
   it('should fetch users from cache with offset and limit', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee14() {
-    var _ref33, _ref34, users, isCached;
+    var limit, _ref33, _ref34, users, isCached;
 
     return _regenerator2.default.wrap(function _callee14$(_context14) {
       while (1) {
         switch (_context14.prev = _context14.next) {
           case 0:
-            _context14.next = 2;
-            return UserCacher.findAllCached(cacheKey, { include: [GitHubUser], offset: 0, limit: 1 });
+            limit = 1;
+            _context14.next = 3;
+            return UserCacher.findAllCached(cacheKey, { offset: 1, limit: limit });
 
-          case 2:
+          case 3:
             _ref33 = _context14.sent;
             _ref34 = (0, _slicedToArray3.default)(_ref33, 2);
             users = _ref34[0];
             isCached = _ref34[1];
 
             _should2.default.exist(users);
-            users.length.should.equal(1);
+            users.length.should.equal(limit);
             isCached.should.equal(true);
-            users[0].githubUser.username.should.equal('idangozlan');
-            users[0].githubUser.get('username').should.equal('idangozlan');
+            users[0].username.should.equal('idan2');
+            users[0].get('username').should.equal('idan2');
 
-          case 11:
+          case 12:
           case 'end':
             return _context14.stop();
         }

--- a/lib/test/sequelize-redis.js
+++ b/lib/test/sequelize-redis.js
@@ -219,8 +219,8 @@ describe('Sequelize-Redis-Cache', function () {
             _should2.default.exist(users);
             users.length.should.equal(2);
             isCached.should.equal(false);
-            users[0].username.should.equal('idan');
-            users[1].username.should.equal('idan2');
+            users.toString().includes('[object SequelizeInstance').should.equal(false);
+            console.log(users);
 
           case 12:
           case 'end':

--- a/lib/test/sequelize-redis.js
+++ b/lib/test/sequelize-redis.js
@@ -220,9 +220,8 @@ describe('Sequelize-Redis-Cache', function () {
             users.length.should.equal(2);
             isCached.should.equal(false);
             users.toString().includes('[object SequelizeInstance').should.equal(false);
-            console.log(users);
 
-          case 12:
+          case 11:
           case 'end':
             return _context3.stop();
         }
@@ -508,15 +507,45 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee13, undefined);
   })));
 
-  it('should fetch user with includes from database', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee14() {
-    var _ref33, _ref34, user, isCached;
+  it('should fetch users from cache with offset and limit', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee14() {
+    var _ref33, _ref34, users, isCached;
 
     return _regenerator2.default.wrap(function _callee14$(_context14) {
       while (1) {
         switch (_context14.prev = _context14.next) {
           case 0:
+            _context14.next = 2;
+            return UserCacher.findAllCached(cacheKey, { include: [GitHubUser], offset: 0, limit: 1 });
+
+          case 2:
+            _ref33 = _context14.sent;
+            _ref34 = (0, _slicedToArray3.default)(_ref33, 2);
+            users = _ref34[0];
+            isCached = _ref34[1];
+
+            _should2.default.exist(users);
+            users.length.should.equal(1);
+            isCached.should.equal(true);
+            users[0].githubUser.username.should.equal('idangozlan');
+            users[0].githubUser.get('username').should.equal('idangozlan');
+
+          case 11:
+          case 'end':
+            return _context14.stop();
+        }
+      }
+    }, _callee14, undefined);
+  })));
+
+  it('should fetch user with includes from database', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee15() {
+    var _ref36, _ref37, user, isCached;
+
+    return _regenerator2.default.wrap(function _callee15$(_context15) {
+      while (1) {
+        switch (_context15.prev = _context15.next) {
+          case 0:
             redisClient.del(cacheKey);
-            _context14.next = 3;
+            _context15.next = 3;
             return UserCacher.findOneCached(cacheKey, {
               where: {
                 id: 1
@@ -525,10 +554,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 3:
-            _ref33 = _context14.sent;
-            _ref34 = (0, _slicedToArray3.default)(_ref33, 2);
-            user = _ref34[0];
-            isCached = _ref34[1];
+            _ref36 = _context15.sent;
+            _ref37 = (0, _slicedToArray3.default)(_ref36, 2);
+            user = _ref37[0];
+            isCached = _ref37[1];
 
             isCached.should.equal(false);
             _should2.default.exist(user);
@@ -538,20 +567,20 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 12:
           case 'end':
-            return _context14.stop();
+            return _context15.stop();
         }
       }
-    }, _callee14, undefined);
+    }, _callee15, undefined);
   })));
 
-  it('should fetch user with includes from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee15() {
-    var _ref36, _ref37, user, isCached;
+  it('should fetch user with includes from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee16() {
+    var _ref39, _ref40, user, isCached;
 
-    return _regenerator2.default.wrap(function _callee15$(_context15) {
+    return _regenerator2.default.wrap(function _callee16$(_context16) {
       while (1) {
-        switch (_context15.prev = _context15.next) {
+        switch (_context16.prev = _context16.next) {
           case 0:
-            _context15.next = 2;
+            _context16.next = 2;
             return UserCacher.findOneCached(cacheKey, {
               where: {
                 id: 1
@@ -560,10 +589,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 2:
-            _ref36 = _context15.sent;
-            _ref37 = (0, _slicedToArray3.default)(_ref36, 2);
-            user = _ref37[0];
-            isCached = _ref37[1];
+            _ref39 = _context16.sent;
+            _ref40 = (0, _slicedToArray3.default)(_ref39, 2);
+            user = _ref40[0];
+            isCached = _ref40[1];
 
             isCached.should.equal(true);
             _should2.default.exist(user);
@@ -573,21 +602,21 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 11:
           case 'end':
-            return _context15.stop();
+            return _context16.stop();
         }
       }
-    }, _callee15, undefined);
+    }, _callee16, undefined);
   })));
 
-  it('should findAndCountAll from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee16() {
-    var _ref39, _ref40, res, isCached;
+  it('should findAndCountAll from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee17() {
+    var _ref42, _ref43, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee16$(_context16) {
+    return _regenerator2.default.wrap(function _callee17$(_context17) {
       while (1) {
-        switch (_context16.prev = _context16.next) {
+        switch (_context17.prev = _context17.next) {
           case 0:
             redisClient.del(cacheKey);
-            _context16.next = 3;
+            _context17.next = 3;
             return UserCacher.findAndCountAllCached(cacheKey, {
               where: {
                 username: 'idan'
@@ -595,10 +624,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 3:
-            _ref39 = _context16.sent;
-            _ref40 = (0, _slicedToArray3.default)(_ref39, 2);
-            res = _ref40[0];
-            isCached = _ref40[1];
+            _ref42 = _context17.sent;
+            _ref43 = (0, _slicedToArray3.default)(_ref42, 2);
+            res = _ref43[0];
+            isCached = _ref43[1];
 
 
             isCached.should.equal(false);
@@ -610,20 +639,20 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 13:
           case 'end':
-            return _context16.stop();
+            return _context17.stop();
         }
       }
-    }, _callee16, undefined);
+    }, _callee17, undefined);
   })));
 
-  it('should findAndCountAll from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee17() {
-    var _ref42, _ref43, res, isCached;
+  it('should findAndCountAll from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee18() {
+    var _ref45, _ref46, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee17$(_context17) {
+    return _regenerator2.default.wrap(function _callee18$(_context18) {
       while (1) {
-        switch (_context17.prev = _context17.next) {
+        switch (_context18.prev = _context18.next) {
           case 0:
-            _context17.next = 2;
+            _context18.next = 2;
             return UserCacher.findAndCountAllCached(cacheKey, {
               where: {
                 username: 'idan'
@@ -631,10 +660,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 2:
-            _ref42 = _context17.sent;
-            _ref43 = (0, _slicedToArray3.default)(_ref42, 2);
-            res = _ref43[0];
-            isCached = _ref43[1];
+            _ref45 = _context18.sent;
+            _ref46 = (0, _slicedToArray3.default)(_ref45, 2);
+            res = _ref46[0];
+            isCached = _ref46[1];
 
 
             isCached.should.equal(true);
@@ -646,21 +675,21 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 12:
           case 'end':
-            return _context17.stop();
+            return _context18.stop();
         }
       }
-    }, _callee17, undefined);
+    }, _callee18, undefined);
   })));
 
-  it('should count from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee18() {
-    var _ref45, _ref46, res, isCached;
+  it('should count from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee19() {
+    var _ref48, _ref49, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee18$(_context18) {
+    return _regenerator2.default.wrap(function _callee19$(_context19) {
       while (1) {
-        switch (_context18.prev = _context18.next) {
+        switch (_context19.prev = _context19.next) {
           case 0:
             redisClient.del(cacheKey);
-            _context18.next = 3;
+            _context19.next = 3;
             return UserCacher.countCached(cacheKey, {
               where: {
                 username: 'idan'
@@ -668,10 +697,10 @@ describe('Sequelize-Redis-Cache', function () {
             });
 
           case 3:
-            _ref45 = _context18.sent;
-            _ref46 = (0, _slicedToArray3.default)(_ref45, 2);
-            res = _ref46[0];
-            isCached = _ref46[1];
+            _ref48 = _context19.sent;
+            _ref49 = (0, _slicedToArray3.default)(_ref48, 2);
+            res = _ref49[0];
+            isCached = _ref49[1];
 
 
             isCached.should.equal(false);
@@ -679,39 +708,6 @@ describe('Sequelize-Redis-Cache', function () {
             res.should.equal(1);
 
           case 10:
-          case 'end':
-            return _context18.stop();
-        }
-      }
-    }, _callee18, undefined);
-  })));
-
-  it('should count from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee19() {
-    var _ref48, _ref49, res, isCached;
-
-    return _regenerator2.default.wrap(function _callee19$(_context19) {
-      while (1) {
-        switch (_context19.prev = _context19.next) {
-          case 0:
-            _context19.next = 2;
-            return UserCacher.countCached(cacheKey, {
-              where: {
-                username: 'idan'
-              }
-            });
-
-          case 2:
-            _ref48 = _context19.sent;
-            _ref49 = (0, _slicedToArray3.default)(_ref48, 2);
-            res = _ref49[0];
-            isCached = _ref49[1];
-
-
-            isCached.should.equal(true);
-            _should2.default.exist(res);
-            res.should.equal(1);
-
-          case 9:
           case 'end':
             return _context19.stop();
         }
@@ -719,29 +715,32 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee19, undefined);
   })));
 
-  it('should sum from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee20() {
+  it('should count from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee20() {
     var _ref51, _ref52, res, isCached;
 
     return _regenerator2.default.wrap(function _callee20$(_context20) {
       while (1) {
         switch (_context20.prev = _context20.next) {
           case 0:
-            redisClient.del(cacheKey);
-            _context20.next = 3;
-            return UserCacher.sumCached(cacheKey, 'id');
+            _context20.next = 2;
+            return UserCacher.countCached(cacheKey, {
+              where: {
+                username: 'idan'
+              }
+            });
 
-          case 3:
+          case 2:
             _ref51 = _context20.sent;
             _ref52 = (0, _slicedToArray3.default)(_ref51, 2);
             res = _ref52[0];
             isCached = _ref52[1];
 
 
-            isCached.should.equal(false);
+            isCached.should.equal(true);
             _should2.default.exist(res);
-            res.should.equal(3); // user id 1 + user id 2 = 3
+            res.should.equal(1);
 
-          case 10:
+          case 9:
           case 'end':
             return _context20.stop();
         }
@@ -749,21 +748,51 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee20, undefined);
   })));
 
-  it('should sum from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee21() {
+  it('should sum from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee21() {
     var _ref54, _ref55, res, isCached;
 
     return _regenerator2.default.wrap(function _callee21$(_context21) {
       while (1) {
         switch (_context21.prev = _context21.next) {
           case 0:
-            _context21.next = 2;
+            redisClient.del(cacheKey);
+            _context21.next = 3;
             return UserCacher.sumCached(cacheKey, 'id');
 
-          case 2:
+          case 3:
             _ref54 = _context21.sent;
             _ref55 = (0, _slicedToArray3.default)(_ref54, 2);
             res = _ref55[0];
             isCached = _ref55[1];
+
+
+            isCached.should.equal(false);
+            _should2.default.exist(res);
+            res.should.equal(3); // user id 1 + user id 2 = 3
+
+          case 10:
+          case 'end':
+            return _context21.stop();
+        }
+      }
+    }, _callee21, undefined);
+  })));
+
+  it('should sum from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee22() {
+    var _ref57, _ref58, res, isCached;
+
+    return _regenerator2.default.wrap(function _callee22$(_context22) {
+      while (1) {
+        switch (_context22.prev = _context22.next) {
+          case 0:
+            _context22.next = 2;
+            return UserCacher.sumCached(cacheKey, 'id');
+
+          case 2:
+            _ref57 = _context22.sent;
+            _ref58 = (0, _slicedToArray3.default)(_ref57, 2);
+            res = _ref58[0];
+            isCached = _ref58[1];
 
 
             isCached.should.equal(true);
@@ -772,28 +801,28 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 9:
           case 'end':
-            return _context21.stop();
+            return _context22.stop();
         }
       }
-    }, _callee21, undefined);
+    }, _callee22, undefined);
   })));
 
-  it('should max from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee22() {
-    var _ref57, _ref58, res, isCached;
+  it('should max from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee23() {
+    var _ref60, _ref61, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee22$(_context22) {
+    return _regenerator2.default.wrap(function _callee23$(_context23) {
       while (1) {
-        switch (_context22.prev = _context22.next) {
+        switch (_context23.prev = _context23.next) {
           case 0:
             redisClient.del(cacheKey);
-            _context22.next = 3;
+            _context23.next = 3;
             return UserCacher.maxCached(cacheKey, 'id');
 
           case 3:
-            _ref57 = _context22.sent;
-            _ref58 = (0, _slicedToArray3.default)(_ref57, 2);
-            res = _ref58[0];
-            isCached = _ref58[1];
+            _ref60 = _context23.sent;
+            _ref61 = (0, _slicedToArray3.default)(_ref60, 2);
+            res = _ref61[0];
+            isCached = _ref61[1];
 
 
             isCached.should.equal(false);
@@ -801,35 +830,6 @@ describe('Sequelize-Redis-Cache', function () {
             res.should.equal(2); // user id 2
 
           case 10:
-          case 'end':
-            return _context22.stop();
-        }
-      }
-    }, _callee22, undefined);
-  })));
-
-  it('should max from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee23() {
-    var _ref60, _ref61, res, isCached;
-
-    return _regenerator2.default.wrap(function _callee23$(_context23) {
-      while (1) {
-        switch (_context23.prev = _context23.next) {
-          case 0:
-            _context23.next = 2;
-            return UserCacher.maxCached(cacheKey, 'id');
-
-          case 2:
-            _ref60 = _context23.sent;
-            _ref61 = (0, _slicedToArray3.default)(_ref60, 2);
-            res = _ref61[0];
-            isCached = _ref61[1];
-
-
-            isCached.should.equal(true);
-            _should2.default.exist(res);
-            res.should.equal(2); // user id 2
-
-          case 9:
           case 'end':
             return _context23.stop();
         }
@@ -837,22 +837,51 @@ describe('Sequelize-Redis-Cache', function () {
     }, _callee23, undefined);
   })));
 
-  it('should min from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee24() {
+  it('should max from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee24() {
     var _ref63, _ref64, res, isCached;
 
     return _regenerator2.default.wrap(function _callee24$(_context24) {
       while (1) {
         switch (_context24.prev = _context24.next) {
           case 0:
-            redisClient.del(cacheKey);
-            _context24.next = 3;
-            return UserCacher.minCached(cacheKey, 'id');
+            _context24.next = 2;
+            return UserCacher.maxCached(cacheKey, 'id');
 
-          case 3:
+          case 2:
             _ref63 = _context24.sent;
             _ref64 = (0, _slicedToArray3.default)(_ref63, 2);
             res = _ref64[0];
             isCached = _ref64[1];
+
+
+            isCached.should.equal(true);
+            _should2.default.exist(res);
+            res.should.equal(2); // user id 2
+
+          case 9:
+          case 'end':
+            return _context24.stop();
+        }
+      }
+    }, _callee24, undefined);
+  })));
+
+  it('should min from db', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee25() {
+    var _ref66, _ref67, res, isCached;
+
+    return _regenerator2.default.wrap(function _callee25$(_context25) {
+      while (1) {
+        switch (_context25.prev = _context25.next) {
+          case 0:
+            redisClient.del(cacheKey);
+            _context25.next = 3;
+            return UserCacher.minCached(cacheKey, 'id');
+
+          case 3:
+            _ref66 = _context25.sent;
+            _ref67 = (0, _slicedToArray3.default)(_ref66, 2);
+            res = _ref67[0];
+            isCached = _ref67[1];
 
 
             isCached.should.equal(false);
@@ -861,27 +890,27 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 10:
           case 'end':
-            return _context24.stop();
+            return _context25.stop();
         }
       }
-    }, _callee24, undefined);
+    }, _callee25, undefined);
   })));
 
-  it('should min from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee25() {
-    var _ref66, _ref67, res, isCached;
+  it('should min from cache', (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee26() {
+    var _ref69, _ref70, res, isCached;
 
-    return _regenerator2.default.wrap(function _callee25$(_context25) {
+    return _regenerator2.default.wrap(function _callee26$(_context26) {
       while (1) {
-        switch (_context25.prev = _context25.next) {
+        switch (_context26.prev = _context26.next) {
           case 0:
-            _context25.next = 2;
+            _context26.next = 2;
             return UserCacher.minCached(cacheKey, 'id');
 
           case 2:
-            _ref66 = _context25.sent;
-            _ref67 = (0, _slicedToArray3.default)(_ref66, 2);
-            res = _ref67[0];
-            isCached = _ref67[1];
+            _ref69 = _context26.sent;
+            _ref70 = (0, _slicedToArray3.default)(_ref69, 2);
+            res = _ref70[0];
+            isCached = _ref70[1];
 
 
             isCached.should.equal(true);
@@ -890,9 +919,9 @@ describe('Sequelize-Redis-Cache', function () {
 
           case 9:
           case 'end':
-            return _context25.stop();
+            return _context26.stop();
         }
       }
-    }, _callee25, undefined);
+    }, _callee26, undefined);
   })));
 });

--- a/src/SequelizeRedisModel.js
+++ b/src/SequelizeRedisModel.js
@@ -79,7 +79,7 @@ export default class SequelizeRedisModel {
           if (queryOptions.offset || queryOptions.limit) {
             const offset = queryOptions.offset || 0;
             const limit = queryOptions.limit || result.length;
-            result = result.slice(offset, limit);
+            result = result.splice(offset, limit);
           }
 
         } else {

--- a/src/SequelizeRedisModel.js
+++ b/src/SequelizeRedisModel.js
@@ -58,6 +58,9 @@ export default class SequelizeRedisModel {
 
         if (queryOptions && !!queryOptions.raw) {
           result = parsed;
+          if (queryOptions.offset || queryOptions.limit) {
+            result = result.splice(queryOptions.offset || 0, queryOptions.limit || result.length);
+          }
         } else if (parsed.rows) {
           result = {
             ...parsed,
@@ -77,12 +80,11 @@ export default class SequelizeRedisModel {
           result = this.model.build(parsed, buildOptions);
           
           if (queryOptions.offset || queryOptions.limit) {
-            const offset = queryOptions.offset || 0;
-            const limit = queryOptions.limit || result.length;
-            result = result.splice(offset, limit);
+            result = result.splice(queryOptions.offset || 0, queryOptions.limit || result.length);
           }
 
         } else {
+          
           result = this.model.build(parsed);
         }
 

--- a/src/SequelizeRedisModel.js
+++ b/src/SequelizeRedisModel.js
@@ -54,27 +54,28 @@ export default class SequelizeRedisModel {
       try {
         // console.log('From Cache');
         let result;
-        if (parsed.rows) {
+        const [queryOptions] = args;
+
+        if (queryOptions && !!queryOptions.raw) {
+          result = parsed;
+        } else if (parsed.rows) {
           result = {
             ...parsed,
             rows: parsed.rows.map(parsedRow => this.model.build(parsedRow)),
           };
         } else if (typeof parsed === 'number') {
           result = parsed;
-        } else {
-          const [queryOptions] = args;
-          if (queryOptions) {
-            const buildOptions = {
-              raw: !!queryOptions.raw || false,
-              isNewRecord: !!queryOptions.isNewRecord || false,
-            };
-            if (queryOptions.include) {
-              buildOptions.include = queryOptions.include;
-            }
-            result = this.model.build(parsed, buildOptions);
-          } else {
-            result = this.model.build(parsed);
+        } else if (queryOptions) {
+          const buildOptions = {
+            raw: !!queryOptions.raw,
+            isNewRecord: !!queryOptions.isNewRecord,
+          };
+          if (queryOptions.include) {
+            buildOptions.include = queryOptions.include;
           }
+          result = this.model.build(parsed, buildOptions);
+        } else {
+          result = this.model.build(parsed);
         }
 
         return [result, true];

--- a/src/SequelizeRedisModel.js
+++ b/src/SequelizeRedisModel.js
@@ -73,7 +73,15 @@ export default class SequelizeRedisModel {
           if (queryOptions.include) {
             buildOptions.include = queryOptions.include;
           }
+
           result = this.model.build(parsed, buildOptions);
+          
+          if (queryOptions.offset || queryOptions.limit) {
+            const offset = queryOptions.offset || 0;
+            const limit = queryOptions.limit || result.length;
+            result = result.slice(offset, limit);
+          }
+
         } else {
           result = this.model.build(parsed);
         }

--- a/src/test/sequelize-redis.js
+++ b/src/test/sequelize-redis.js
@@ -10,7 +10,6 @@ runDotenv(); // to run with .env file for local env vars
 bluebird.promisifyAll(redis.RedisClient.prototype);
 bluebird.promisifyAll(redis.Multi.prototype);
 
-
 const db = {
   host: process.env.DB_HOST || 'localhost',
   port: process.env.DB_PORT || 3306,
@@ -134,7 +133,6 @@ describe('Sequelize-Redis-Cache', () => {
     users.length.should.equal(2);
     isCached.should.equal(false);
     users.toString().includes(('[object SequelizeInstance')).should.equal(false);
-    console.log(users);
   });
 
   it('should fetch user from database with cached Sequelize model with original method', async () => {
@@ -212,6 +210,15 @@ describe('Sequelize-Redis-Cache', () => {
     const [users, isCached] = await UserCacher.findAllCached(cacheKey, { include: [GitHubUser] });
     should.exist(users);
     users.length.should.equal(2);
+    isCached.should.equal(true);
+    users[0].githubUser.username.should.equal('idangozlan');
+    users[0].githubUser.get('username').should.equal('idangozlan');
+  });
+
+  it('should fetch users from cache with offset and limit', async () => {
+    const [users, isCached] = await UserCacher.findAllCached(cacheKey, { include: [GitHubUser], offset: 0, limit: 1 });
+    should.exist(users);
+    users.length.should.equal(1);
     isCached.should.equal(true);
     users[0].githubUser.username.should.equal('idangozlan');
     users[0].githubUser.get('username').should.equal('idangozlan');

--- a/src/test/sequelize-redis.js
+++ b/src/test/sequelize-redis.js
@@ -133,8 +133,8 @@ describe('Sequelize-Redis-Cache', () => {
     should.exist(users);
     users.length.should.equal(2);
     isCached.should.equal(false);
-    users[0].username.should.equal('idan');
-    users[1].username.should.equal('idan2');
+    users.toString().includes(('[object SequelizeInstance')).should.equal(false);
+    console.log(users);
   });
 
   it('should fetch user from database with cached Sequelize model with original method', async () => {

--- a/src/test/sequelize-redis.js
+++ b/src/test/sequelize-redis.js
@@ -216,12 +216,13 @@ describe('Sequelize-Redis-Cache', () => {
   });
 
   it('should fetch users from cache with offset and limit', async () => {
-    const [users, isCached] = await UserCacher.findAllCached(cacheKey, { include: [GitHubUser], offset: 0, limit: 1 });
+    const limit = 1;
+    const [users, isCached] = await UserCacher.findAllCached(cacheKey, { offset: 1, limit });
     should.exist(users);
-    users.length.should.equal(1);
+    users.length.should.equal(limit);
     isCached.should.equal(true);
-    users[0].githubUser.username.should.equal('idangozlan');
-    users[0].githubUser.get('username').should.equal('idangozlan');
+    users[0].username.should.equal('idan2');
+    users[0].get('username').should.equal('idan2');
   });
 
   it('should fetch user with includes from database', async () => {

--- a/src/test/sequelize-redis.js
+++ b/src/test/sequelize-redis.js
@@ -215,6 +215,7 @@ describe('Sequelize-Redis-Cache', () => {
     users[0].githubUser.get('username').should.equal('idangozlan');
   });
 
+
   it('should fetch users from cache with offset and limit', async () => {
     const limit = 1;
     const [users, isCached] = await UserCacher.findAllCached(cacheKey, { offset: 1, limit });
@@ -223,6 +224,15 @@ describe('Sequelize-Redis-Cache', () => {
     isCached.should.equal(true);
     users[0].username.should.equal('idan2');
     users[0].get('username').should.equal('idan2');
+  });
+
+  it('should fetch users from cache with offset and limit with raw', async () => {
+    const limit = 1;
+    const [users, isCached] = await UserCacher.findAllCached(cacheKey, { raw: true, offset: 1, limit });
+    should.exist(users);
+    users.length.should.equal(limit);
+    isCached.should.equal(true);
+    users[0].username.should.equal('idan2');
   });
 
   it('should fetch user with includes from database', async () => {


### PR DESCRIPTION
when doing for instance

```
model.findAllCached('myCacheKey', {
   offset: 1,
   limit: 2,
});
```

before was just spitting out the instances generated with model.build.

now, im slicing the result using the queryOptions