### PR TITLE
building from cache with timestamps

### DIFF
--- a/lib/SequelizeRedisModel.js
+++ b/lib/SequelizeRedisModel.js
@@ -91,12 +91,41 @@ function () {
   }
 
   (0, _createClass2.default)(SequelizeRedisModel, [{
+    key: "$build",
+    value: function $build(values, options) {
+      var _this2 = this;
+
+      var model = this.model.build(values, (0, _objectSpread2.default)({}, options, {
+        raw: options.raw || true,
+        include: options.include || []
+      }));
+
+      if (this.model.options.timestamps === true && options && options.isNewRecord === false) {
+        // get the fields being used for timestamps
+        var fields = Object.keys(this.model._timestampAttributes).map(function (key) {
+          return _this2.model._timestampAttributes[key];
+        }); // eslint-disable-line no-underscore-dangle
+        // iterate over them and get the value from cached data
+
+        fields.forEach(function (field) {
+          if (typeof values[field] !== 'undefined') {
+            model.dataValues[field] = values[field];
+          }
+        });
+        model._changed = {}; // eslint-disable-line no-underscore-dangle
+
+        model._previousDataValues = Object.assign({}, model.dataValues); // eslint-disable-line no-underscore-dangle
+      }
+
+      return model;
+    }
+  }, {
     key: "run",
     value: function () {
       var _run = (0, _asyncToGenerator2.default)(
       /*#__PURE__*/
       _regenerator.default.mark(function _callee3(cacheKey, method) {
-        var _this2 = this,
+        var _this3 = this,
             _this$model2;
 
         var cached,
@@ -175,7 +204,9 @@ function () {
                 } else if (parsed.rows) {
                   _result = (0, _objectSpread2.default)({}, parsed, {
                     rows: parsed.rows.map(function (parsedRow) {
-                      return _this2.model.build(parsedRow);
+                      return _this3.$build(parsedRow, {
+                        isNewRecord: false
+                      });
                     })
                   });
                 } else if (typeof parsed === 'number') {
@@ -183,16 +214,19 @@ function () {
                 } else if (queryOptions) {
                   buildOptions = {
                     raw: !!queryOptions.raw,
-                    isNewRecord: !!queryOptions.isNewRecord
+                    isNewRecord: false // forced false since we're already pulling from cache, so it means already was persisted to DB previously
+
                   };
 
                   if (queryOptions.include) {
                     buildOptions.include = queryOptions.include;
                   }
 
-                  _result = this.model.build(parsed, buildOptions);
+                  _result = this.$build(parsed, buildOptions);
                 } else {
-                  _result = this.model.build(parsed);
+                  _result = this.$build(parsed, {
+                    isNewRecord: false
+                  });
                 }
 
                 return _context3.abrupt("return", [_result, true]);

--- a/lib/SequelizeRedisModel.js
+++ b/lib/SequelizeRedisModel.js
@@ -91,6 +91,31 @@ function () {
   }
 
   (0, _createClass2.default)(SequelizeRedisModel, [{
+    key: "$build",
+    value: function $build(values, options) {
+      var model = this.model.build(values, (0, _objectSpread2.default)({}, options, {
+        raw: options.raw || true,
+        include: options.include || []
+      }));
+
+      if (this.model.options.timestamps === true && options && options.isNewRecord === false) {
+        // get the fields being used for timestamps
+        var fields = Object.values(this.model._timestampAttributes); // eslint-disable-line no-underscore-dangle
+        // iterate over them and get the value from cached data
+
+        fields.forEach(function (field) {
+          if (typeof values[field] !== 'undefined') {
+            model.dataValues[field] = values[field];
+          }
+        });
+        model._changed = {}; // eslint-disable-line no-underscore-dangle
+
+        model._previousDataValues = Object.assign({}, model.dataValues); // eslint-disable-line no-underscore-dangle
+      }
+
+      return model;
+    }
+  }, {
     key: "run",
     value: function () {
       var _run = (0, _asyncToGenerator2.default)(
@@ -175,7 +200,9 @@ function () {
                 } else if (parsed.rows) {
                   _result = (0, _objectSpread2.default)({}, parsed, {
                     rows: parsed.rows.map(function (parsedRow) {
-                      return _this2.model.build(parsedRow);
+                      return _this2.$build(parsedRow, {
+                        isNewRecord: false
+                      });
                     })
                   });
                 } else if (typeof parsed === 'number') {
@@ -183,16 +210,19 @@ function () {
                 } else if (queryOptions) {
                   buildOptions = {
                     raw: !!queryOptions.raw,
-                    isNewRecord: !!queryOptions.isNewRecord
+                    isNewRecord: false // forced false since we're already pulling from cache, so it means already was persisted to DB previously
+
                   };
 
                   if (queryOptions.include) {
                     buildOptions.include = queryOptions.include;
                   }
 
-                  _result = this.model.build(parsed, buildOptions);
+                  _result = this.$build(parsed, buildOptions);
                 } else {
-                  _result = this.model.build(parsed);
+                  _result = this.$build(parsed, {
+                    isNewRecord: false
+                  });
                 }
 
                 return _context3.abrupt("return", [_result, true]);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A semi-automatic caching wrapper for Sequelize NodeJS framework",
   "homepage": "https://github.com/idangozlan/sequelize-redis",
   "license": "MIT",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/runtime": "^7.2.0",

--- a/src/SequelizeRedisModel.js
+++ b/src/SequelizeRedisModel.js
@@ -23,10 +23,36 @@ module.exports = class SequelizeRedisModel {
 
     this.model = model;
     this.redisClient = redisPromisifiedClient;
+
     methods.forEach((method) => {
       this[`${method}Cached`] = async (cacheKey, ...args) => this.run(cacheKey, method, ...args);
       this[method] = async (...args) => this.model[method](...args);
     });
+  }
+
+  $build(values, options) {
+    const model = this.model.build(values, {
+      ...options,
+      raw: options.raw || true,
+      include: options.include || [],
+    });
+
+    if (this.model.options.timestamps === true && options && options.isNewRecord === false) {
+      // get the fields being used for timestamps
+      const fields = Object.values(this.model._timestampAttributes); // eslint-disable-line no-underscore-dangle
+
+      // iterate over them and get the value from cached data
+      fields.forEach((field) => {
+        if (typeof values[field] !== 'undefined') {
+          model.dataValues[field] = values[field];
+        }
+      });
+
+      model._changed = {}; // eslint-disable-line no-underscore-dangle
+      model._previousDataValues = Object.assign({}, model.dataValues); // eslint-disable-line no-underscore-dangle
+    }
+
+    return model;
   }
 
   async run(cacheKey, method, ...args) {
@@ -62,21 +88,21 @@ module.exports = class SequelizeRedisModel {
         } else if (parsed.rows) {
           result = {
             ...parsed,
-            rows: parsed.rows.map(parsedRow => this.model.build(parsedRow)),
+            rows: parsed.rows.map(parsedRow => this.$build(parsedRow, { isNewRecord: false })),
           };
         } else if (typeof parsed === 'number') {
           result = parsed;
         } else if (queryOptions) {
           const buildOptions = {
             raw: !!queryOptions.raw,
-            isNewRecord: !!queryOptions.isNewRecord,
+            isNewRecord: false, // forced false since we're already pulling from cache, so it means already was persisted to DB previously
           };
           if (queryOptions.include) {
             buildOptions.include = queryOptions.include;
           }
-          result = this.model.build(parsed, buildOptions);
+          result = this.$build(parsed, buildOptions);
         } else {
-          result = this.model.build(parsed);
+          result = this.$build(parsed, { isNewRecord: false });
         }
 
         return [result, true];


### PR DESCRIPTION
i noticed that the retrieved cache data was not building the model instance with the timestamp attributes. this is default behavior from sequelize unfortunately.

added 2 test cases for timestamp with custom attribute name and defaults.